### PR TITLE
Fix path to weights

### DIFF
--- a/lpips_pytorch/modules/utils.py
+++ b/lpips_pytorch/modules/utils.py
@@ -11,7 +11,7 @@ def normalize_activation(x, eps=1e-10):
 def get_state_dict(net_type: str = 'alex', version: str = '0.1'):
     # build url
     url = 'https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/' \
-        + f'master/models/weights/v{version}/{net_type}.pth'
+        + f'master/lpips/weights/v{version}/{net_type}.pth'
 
     # download
     old_state_dict = torch.hub.load_state_dict_from_url(


### PR DESCRIPTION
If I understand correctly, fixes [this recently opened issue](https://github.com/S-aiueo32/lpips-pytorch/issues/2).

Another possible solution would be to refer to your fork with
```python
url = 'https://raw.githubusercontent.com/S-aiueo32/PerceptualSimilarity/' \
    + f'master/models/weights/v{version}/{net_type}.pth'
```